### PR TITLE
feat: auto-detect DZ heartbeat port and show LINK status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 Cargo.lock
+.claude
 
 # Local / sensitive — do not commit
 .env

--- a/crates/shred-ingest/src/fan_in.rs
+++ b/crates/shred-ingest/src/fan_in.rs
@@ -62,6 +62,8 @@ pub struct ShredTxSource {
     pub shred_version: Option<u16>,
     /// Optional capture channel; forwarded to ShredReceiver for the hot-path tap.
     pub capture_tx: Option<crossbeam_channel::Sender<CaptureEvent>>,
+    /// DZ heartbeat port. Defaults to 5765 if None.
+    pub heartbeat_port: Option<u16>,
 }
 
 impl TxSource for ShredTxSource {
@@ -90,6 +92,11 @@ impl TxSource for ShredTxSource {
         let name = self.name;
         let race_tx = race.as_ref().map(|r| r.sender());
         let capture_tx = self.capture_tx.clone();
+
+        // Clone for heartbeat listener before recv thread moves them.
+        let hb_mcast = self.multicast_addr.clone();
+        let hb_iface = self.interface.clone();
+        let hb_metrics = metrics.clone();
 
         let recv_handle = std::thread::Builder::new()
             .name(format!("{}-recv", name))
@@ -124,7 +131,20 @@ impl TxSource for ShredTxSource {
             })
             .expect("failed to spawn decode thread");
 
-        vec![recv_handle, decode_handle]
+        // Spawn a separate heartbeat listener. It auto-detects the DZ heartbeat
+        // port by sniffing the interface, or uses the configured override.
+        let mut handles = vec![recv_handle, decode_handle];
+        match crate::receiver::ShredReceiver::spawn_heartbeat_listener(
+            hb_mcast,
+            hb_iface,
+            hb_metrics,
+            name,
+            self.heartbeat_port,
+        ) {
+            Ok(hb_handle) => handles.push(hb_handle),
+            Err(e) => tracing::warn!("{name}: DZ heartbeat listener failed to start: {e}"),
+        }
+        handles
     }
 }
 

--- a/crates/shred-ingest/src/receiver.rs
+++ b/crates/shred-ingest/src/receiver.rs
@@ -540,6 +540,101 @@ impl ShredReceiver {
         }
     }
 
+    /// Spawn a thread that auto-detects the DoubleZero heartbeat port by
+    /// sniffing the interface, then listens on it permanently. DZ sends
+    /// heartbeats on the same multicast group but a different UDP port than
+    /// shred data, so the main receiver socket never sees them.
+    ///
+    /// If `heartbeat_port` is `Some`, skips detection and uses that port.
+    /// Otherwise probes the interface for up to 5 seconds with `AF_PACKET`,
+    /// falling back to port 5765 if no heartbeat is detected.
+    pub fn spawn_heartbeat_listener(
+        multicast_addr: String,
+        interface: String,
+        metrics: Arc<SourceMetrics>,
+        name: &'static str,
+        heartbeat_port: Option<u16>,
+    ) -> Result<std::thread::JoinHandle<()>> {
+        let handle = std::thread::Builder::new()
+            .name(format!("{}-heartbeat", name))
+            .spawn(move || {
+                let port = heartbeat_port.unwrap_or_else(|| {
+                    eprintln!("{name}: probing {interface} for DZ heartbeat port...");
+                    match detect_heartbeat_port(&interface) {
+                        Some(p) => {
+                            eprintln!("{name}: detected DZ heartbeat on port {p}");
+                            p
+                        }
+                        None => {
+                            eprintln!(
+                                "{name}: no DZ heartbeat detected on {interface}, \
+                                 falling back to port 5765"
+                            );
+                            5765
+                        }
+                    }
+                });
+
+                let mcast_addr: Ipv4Addr = match multicast_addr.parse() {
+                    Ok(a) => a,
+                    Err(e) => {
+                        eprintln!("{name}: heartbeat: bad multicast addr: {e}");
+                        return;
+                    }
+                };
+                let iface_addr = match Self::resolve_interface_addr(&interface) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        eprintln!("{name}: heartbeat: resolve interface: {e}");
+                        return;
+                    }
+                };
+                let socket = match Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("{name}: heartbeat: socket create: {e}");
+                        return;
+                    }
+                };
+                socket.set_reuse_address(true).ok();
+                socket.set_recv_buffer_size(64 * 1024).ok();
+                let bind_addr = SocketAddrV4::new(mcast_addr, port);
+                if let Err(e) = socket.bind(&bind_addr.into()) {
+                    eprintln!("{name}: heartbeat bind {mcast_addr}:{port}: {e}");
+                    return;
+                }
+                if let Err(e) = socket.join_multicast_v4(&mcast_addr, &iface_addr) {
+                    eprintln!("{name}: heartbeat join multicast: {e}");
+                    return;
+                }
+
+                eprintln!("{name}: heartbeat listener on {multicast_addr}:{port}");
+                let mut buf = [0u8; 64];
+                loop {
+                    let buf_uninit: &mut [std::mem::MaybeUninit<u8>] = unsafe {
+                        std::slice::from_raw_parts_mut(buf.as_mut_ptr() as _, buf.len())
+                    };
+                    match socket.recv(buf_uninit) {
+                        Ok(n) if n >= 4 => {
+                            if buf[0] == 0x44
+                                && buf[1] == 0x5A
+                                && buf[2] == 0x00
+                                && buf[3] == 0x01
+                            {
+                                metrics.last_heartbeat_ns.store(
+                                    crate::metrics::now_ns(),
+                                    std::sync::atomic::Ordering::Relaxed,
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            })?;
+
+        Ok(handle)
+    }
+
     fn resolve_interface_addr(interface: &str) -> Result<Ipv4Addr> {
         #[cfg(target_os = "linux")]
         {
@@ -577,6 +672,125 @@ impl ShredReceiver {
             Ok(Ipv4Addr::LOCALHOST)
         }
     }
+}
+
+/// Sniff the interface with `AF_PACKET` for up to 5 seconds looking for
+/// DoubleZero heartbeat packets (4-byte UDP, magic `DZ\x00\x01`).
+/// Returns the UDP destination port if found.
+#[cfg(target_os = "linux")]
+fn detect_heartbeat_port(interface: &str) -> Option<u16> {
+    use std::time::{Duration, Instant};
+
+    const PROBE_SECS: u64 = 5;
+
+    // AF_PACKET + SOCK_DGRAM: all IP frames on the interface, link header stripped.
+    let sock = unsafe {
+        libc::socket(
+            libc::AF_PACKET,
+            libc::SOCK_DGRAM,
+            (libc::ETH_P_IP as u16).to_be() as libc::c_int,
+        )
+    };
+    if sock < 0 {
+        return None;
+    }
+
+    // Look up interface index.
+    let ifindex = {
+        let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
+        let name = interface.as_bytes();
+        let n = name.len().min(libc::IFNAMSIZ - 1);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                name.as_ptr(),
+                ifr.ifr_name.as_mut_ptr() as *mut u8,
+                n,
+            );
+            if libc::ioctl(sock, libc::SIOCGIFINDEX, &ifr) < 0 {
+                libc::close(sock);
+                return None;
+            }
+            ifr.ifr_ifru.ifru_ifindex
+        }
+    };
+
+    // Bind to the interface.
+    let mut sll: libc::sockaddr_ll = unsafe { std::mem::zeroed() };
+    sll.sll_family = libc::AF_PACKET as u16;
+    sll.sll_protocol = (libc::ETH_P_IP as u16).to_be();
+    sll.sll_ifindex = ifindex;
+    unsafe {
+        if libc::bind(
+            sock,
+            &sll as *const _ as _,
+            std::mem::size_of_val(&sll) as u32,
+        ) < 0
+        {
+            libc::close(sock);
+            return None;
+        }
+    }
+
+    // Recv timeout — slightly longer than probe window so the loop's
+    // Instant check is the effective deadline.
+    let tv = libc::timeval { tv_sec: (PROBE_SECS + 1) as libc::time_t, tv_usec: 0 };
+    unsafe {
+        libc::setsockopt(
+            sock,
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            &tv as *const _ as _,
+            std::mem::size_of_val(&tv) as u32,
+        );
+    }
+
+    let mut buf = [0u8; 2048];
+    let deadline = Instant::now() + Duration::from_secs(PROBE_SECS);
+
+    let result = loop {
+        if Instant::now() >= deadline {
+            break None;
+        }
+        let n = unsafe { libc::recv(sock, buf.as_mut_ptr() as _, buf.len(), 0) };
+        if n <= 0 {
+            break None;
+        }
+        let n = n as usize;
+
+        // IP header: byte 0 low nibble = IHL (words), byte 9 = protocol.
+        if n < 28 {
+            continue; // 20 (IP min) + 8 (UDP hdr)
+        }
+        let ihl = ((buf[0] & 0x0F) as usize) * 4;
+        if buf[9] != 17 || n < ihl + 12 {
+            continue; // not UDP or too short
+        }
+
+        // UDP header at offset ihl: src_port(2) dst_port(2) length(2) checksum(2).
+        let dst_port = u16::from_be_bytes([buf[ihl + 2], buf[ihl + 3]]);
+        let udp_len = u16::from_be_bytes([buf[ihl + 4], buf[ihl + 5]]) as usize;
+        let payload_start = ihl + 8;
+        let payload_len = udp_len.saturating_sub(8);
+
+        if payload_len == 4
+            && n >= payload_start + 4
+            && buf[payload_start] == 0x44
+            && buf[payload_start + 1] == 0x5A
+            && buf[payload_start + 2] == 0x00
+            && buf[payload_start + 3] == 0x01
+        {
+            break Some(dst_port);
+        }
+    };
+
+    unsafe { libc::close(sock); }
+    result
+}
+
+/// Non-Linux stub — heartbeat detection requires `AF_PACKET`.
+#[cfg(not(target_os = "linux"))]
+fn detect_heartbeat_port(_interface: &str) -> Option<u16> {
+    None
 }
 
 /// Sample CLOCK_REALTIME − CLOCK_MONOTONIC_RAW once at startup.

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,11 @@ pub struct SourceEntry {
     /// Useful during forks or network upgrades. Omit to accept all versions.
     #[serde(default)]
     pub shred_version: Option<u16>,
+    /// UDP port for DoubleZero heartbeat packets (shred only). Defaults to 5765.
+    /// DZ sends heartbeats on the same multicast group but a separate port from
+    /// shred data. Set this if the heartbeat port differs from the default.
+    #[serde(default)]
+    pub heartbeat_port: Option<u16>,
 }
 
 impl ProbeConfig {
@@ -148,6 +153,7 @@ impl ProbeConfig {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 },
                 SourceEntry {
                     name: "jito-shredstream".into(),
@@ -160,6 +166,7 @@ impl ProbeConfig {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 },
                 SourceEntry {
                     name: "rpc".into(),
@@ -172,6 +179,7 @@ impl ProbeConfig {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 },
             ],
         }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -186,6 +186,7 @@ pub fn run(config: &ProbeConfig, config_path: &Path) -> Result<()> {
                         pin_recv_core: None,
                         pin_decode_core: None,
                         shred_version: None,
+                    heartbeat_port: None,
                     });
                 }
 
@@ -284,6 +285,7 @@ pub fn run(config: &ProbeConfig, config_path: &Path) -> Result<()> {
                                 pin_recv_core: None,
                                 pin_decode_core: None,
                                 shred_version: None,
+                                heartbeat_port: None,
                             });
                         }
                     }
@@ -306,6 +308,7 @@ pub fn run(config: &ProbeConfig, config_path: &Path) -> Result<()> {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 });
             }
             _ => {
@@ -785,6 +788,7 @@ fn collect_manual_sources() -> Vec<SourceEntry> {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 }
             }
             "2" | "unicast" => {
@@ -809,6 +813,7 @@ fn collect_manual_sources() -> Vec<SourceEntry> {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 }
             }
             "3" | "rpc" => {
@@ -825,6 +830,7 @@ fn collect_manual_sources() -> Vec<SourceEntry> {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 }
             }
             "4" | "geyser" => {
@@ -843,6 +849,7 @@ fn collect_manual_sources() -> Vec<SourceEntry> {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 }
             }
             "5" | "jito-grpc" => {
@@ -860,6 +867,7 @@ fn collect_manual_sources() -> Vec<SourceEntry> {
                     pin_recv_core: None,
                     pin_decode_core: None,
                     shred_version: None,
+                    heartbeat_port: None,
                 }
             }
             _ => {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -447,6 +447,7 @@ pub fn build_source(
                 pin_decode_core: entry.pin_decode_core,
                 shred_version: entry.shred_version,
                 capture_tx,
+                heartbeat_port: entry.heartbeat_port,  // None = auto-detect
             })
         }
         "rpc" => {


### PR DESCRIPTION
DZ sends heartbeats on the same multicast group but a separate UDP port from shred data.  The main receiver socket never sees them, so the LINK column always showed "—" for shred sources.

Fix: spawn a lightweight heartbeat listener thread per shred source. On startup it probes the interface with AF_PACKET for up to 5 s to discover the heartbeat port, then binds a normal multicast UDP socket and updates last_heartbeat_ns on every DZ magic packet.

An optional `heartbeat_port` field in probe.toml lets users override the auto-detected port.