### PR TITLE
timing fixes

### DIFF
--- a/crates/shred-ingest/src/decoder.rs
+++ b/crates/shred-ingest/src/decoder.rs
@@ -187,6 +187,11 @@ struct SlotState {
     /// Whether we've seen the last shred in slot
     last_seen: bool,
     last_touch_ns: u64,
+    /// Earliest kernel receive timestamp (ns) across all shreds in this slot.
+    /// Used as the shred-side timestamp for lead-time computation so the
+    /// measurement reflects when the first shred data arrived, not when
+    /// enough shreds accumulated to trigger deserialization.
+    earliest_recv_ns: u64,
     /// Number of transactions decoded from this slot
     txs_decoded: u32,
     /// Unique data shreds received (direct + FEC-recovered)
@@ -212,6 +217,7 @@ impl SlotState {
             max_index: 0,
             last_seen: false,
             last_touch_ns: now,
+            earliest_recv_ns: u64::MAX,
             txs_decoded: 0,
             shreds_seen: 0,
             fec_recovered_count: 0,
@@ -505,6 +511,9 @@ impl ShredDecoder {
                             SlotState::new(now)
                         });
                         slot_state.last_touch_ns = now;
+                        if raw_shred.recv_timestamp_ns < slot_state.earliest_recv_ns {
+                            slot_state.earliest_recv_ns = raw_shred.recv_timestamp_ns;
+                        }
 
                         let mut recovered_count = 0u64;
                         for (data_shard_idx, shard_bytes) in recovered {
@@ -571,10 +580,12 @@ impl ShredDecoder {
                                     let decoded = DecodedTx {
                                         transaction: tx,
                                         slot,
-                                        shred_recv_ns: raw_shred.recv_timestamp_ns,
+                                        shred_recv_ns: slot_state.earliest_recv_ns,
                                         decode_done_ns: decode_done,
                                     };
-                                    let _ = self.tx.try_send(decoded);
+                                    if self.tx.try_send(decoded).is_err() {
+                                        self.metrics.txs_dropped.fetch_add(1, Relaxed);
+                                    }
                                 }
                             }
                         }
@@ -597,6 +608,9 @@ impl ShredDecoder {
                 SlotState::new(now)
             });
             state.last_touch_ns = now;
+            if raw_shred.recv_timestamp_ns < state.earliest_recv_ns {
+                state.earliest_recv_ns = raw_shred.recv_timestamp_ns;
+            }
 
             let data_shard_idx = shred_index.checked_sub(fec_set_index).map(|i| i as usize);
             if let Some(shard_pos) = data_shard_idx {
@@ -650,7 +664,7 @@ impl ShredDecoder {
                     let decoded = DecodedTx {
                         transaction: tx,
                         slot,
-                        shred_recv_ns: raw_shred.recv_timestamp_ns,
+                        shred_recv_ns: state.earliest_recv_ns,
                         decode_done_ns: decode_done,
                     };
                     let _ = self.tx.try_send(decoded);

--- a/crates/shred-ingest/src/fan_in.rs
+++ b/crates/shred-ingest/src/fan_in.rs
@@ -362,6 +362,14 @@ impl TxSource for RpcTxSource {
 // FanInSource
 // ---------------------------------------------------------------------------
 
+/// Recorded when a cross-tier match occurs, so a later faster-shred update
+/// can correct the lead time measurement.
+struct CrossTierRecord {
+    rpc_ns: u64,
+    old_lead_us: i64,
+    shred_name: &'static str,
+}
+
 /// Tracks the first arrival of a transaction signature in the dedup map.
 struct FirstArrival {
     /// Receive timestamp from the winning source (nanoseconds)
@@ -370,6 +378,9 @@ struct FirstArrival {
     is_rpc: bool,
     /// Metrics handle for the winning source, used to record lead time
     metrics: Arc<SourceMetrics>,
+    /// Set after a cross-tier lead time is recorded so that a subsequent
+    /// faster shred source can correct the measurement.
+    cross_tier: Option<CrossTierRecord>,
 }
 
 /// Multi-source fan-in with deduplication.
@@ -463,6 +474,7 @@ impl FanInSource {
                                     recv_ns: decoded.shred_recv_ns,
                                     is_rpc: source_is_rpc,
                                     metrics: source_metrics.clone(),
+                                    cross_tier: None,
                                 });
                                 let _ = out_tx_clone.try_send(decoded);
                             }
@@ -475,6 +487,42 @@ impl FanInSource {
                                 // stored entry so the subsequent RPC comparison uses the fastest shred.
                                 if source_is_rpc == e.get().is_rpc {
                                     if !source_is_rpc && decoded.shred_recv_ns < e.get().recv_ns {
+                                        // A faster shred source arrived. If a cross-tier
+                                        // lead time was already recorded with the slower
+                                        // timestamp, correct the measurement.
+                                        if let Some(ref ct) = e.get().cross_tier {
+                                            let new_lead_us = (ct.rpc_ns as i64
+                                                - decoded.shred_recv_ns as i64)
+                                                / 1000;
+                                            // Adjust sum: remove old contribution, add corrected
+                                            e.get().metrics.lead_time_sum_us.fetch_sub(
+                                                ct.old_lead_us,
+                                                Relaxed,
+                                            );
+                                            source_metrics
+                                                .lead_time_sum_us
+                                                .fetch_add(new_lead_us, Relaxed);
+                                            // Adjust win count if direction changed
+                                            if ct.old_lead_us > 0 {
+                                                e.get()
+                                                    .metrics
+                                                    .lead_wins
+                                                    .fetch_sub(1, Relaxed);
+                                            }
+                                            if new_lead_us > 0 {
+                                                source_metrics
+                                                    .lead_wins
+                                                    .fetch_add(1, Relaxed);
+                                            }
+                                            // Push corrected sample to reservoir; old ages out
+                                            source_metrics
+                                                .lead_time_reservoir
+                                                .lock()
+                                                .unwrap()
+                                                .push(new_lead_us);
+                                            race_tracker_relay
+                                                .record_tx_race(ct.shred_name, new_lead_us);
+                                        }
                                         let m = e.get_mut();
                                         m.recv_ns = decoded.shred_recv_ns;
                                         m.metrics = source_metrics.clone();
@@ -503,6 +551,18 @@ impl FanInSource {
                                     source_metrics.record_lead_time_us(lead_us);
                                 }
                                 race_tracker_relay.record_tx_race(shred_name, lead_us);
+
+                                // Store cross-tier record so a later faster-shred can correct.
+                                // Only relevant when the stored entry is a shred (a faster
+                                // shred could arrive later and improve the measurement).
+                                if !e.get().is_rpc {
+                                    let m = e.get_mut();
+                                    m.cross_tier = Some(CrossTierRecord {
+                                        rpc_ns,
+                                        old_lead_us: lead_us,
+                                        shred_name,
+                                    });
+                                }
                             }
                         }
                     }
@@ -572,6 +632,7 @@ mod tests {
                     recv_ns: 100_000,
                     is_rpc: false,
                     metrics: metrics.clone(),
+                    cross_tier: None,
                 });
             }
             Entry::Occupied(_) => {
@@ -589,6 +650,7 @@ mod tests {
                     recv_ns: 200_000,
                     is_rpc: false,
                     metrics: metrics.clone(),
+                    cross_tier: None,
                 });
             }
             Entry::Occupied(_) => {

--- a/crates/shred-ingest/src/geyser_source.rs
+++ b/crates/shred-ingest/src/geyser_source.rs
@@ -146,7 +146,7 @@ async fn run_geyser(
         let msg = msg?;
         if let Some(UpdateOneof::Transaction(tx_update)) = msg.update_oneof {
             if let Some(tx_info) = tx_update.transaction {
-                let recv_ns = metrics::now_ns();
+                let recv_ns = metrics::now_realtime_ns();
                 let slot = tx_update.slot;
 
                 metrics.txs_decoded.fetch_add(1, Relaxed);

--- a/crates/shred-ingest/src/jetstream_source.rs
+++ b/crates/shred-ingest/src/jetstream_source.rs
@@ -172,7 +172,7 @@ async fn run_jetstream(
 
     while let Some(msg) = stream.next().await {
         let msg = msg?;
-        let recv_ns = metrics::now_ns();
+        let recv_ns = metrics::now_realtime_ns();
 
         metrics.txs_decoded.fetch_add(1, Relaxed);
 

--- a/crates/shred-ingest/src/jito_source.rs
+++ b/crates/shred-ingest/src/jito_source.rs
@@ -149,7 +149,7 @@ async fn run_jito_shredstream(
 
     while let Some(msg) = stream.next().await {
         let msg = msg?;
-        let recv_ns = metrics::now_ns();
+        let recv_ns = metrics::now_realtime_ns();
         let slot = msg.slot;
 
         // The proxy sends bincode-serialized Vec<solana_entry::entry::Entry>

--- a/crates/shred-ingest/src/source_metrics.rs
+++ b/crates/shred-ingest/src/source_metrics.rs
@@ -42,7 +42,7 @@ pub struct SlotStats {
 
 const RESERVOIR_CAP: usize = 4096;
 
-struct LeadTimeReservoir {
+pub struct LeadTimeReservoir {
     buf: [i64; RESERVOIR_CAP],
     /// Number of valid entries: 0..=RESERVOIR_CAP
     len: usize,
@@ -59,7 +59,7 @@ impl LeadTimeReservoir {
         }
     }
 
-    fn push(&mut self, v: i64) {
+    pub fn push(&mut self, v: i64) {
         self.buf[self.pos] = v;
         self.pos = (self.pos + 1) % RESERVOIR_CAP;
         if self.len < RESERVOIR_CAP {
@@ -124,6 +124,8 @@ pub struct SourceMetrics {
 
     // Tx flow
     pub txs_decoded: AtomicU64,
+    /// Decoded transactions dropped because the decoder→relay channel was full.
+    pub txs_dropped: AtomicU64,
     pub txs_emitted: AtomicU64,
     /// Won the fan-in dedup race (first arrival)
     pub txs_first: AtomicU64,
@@ -139,7 +141,7 @@ pub struct SourceMetrics {
     /// >LEAD_TIME_MAX_US after this source — almost certainly backfilled/replayed data.
     pub backfill_count: AtomicU64,
     /// Rolling reservoir of recent samples; sorted at snapshot time to compute percentiles.
-    lead_time_reservoir: Mutex<LeadTimeReservoir>,
+    pub lead_time_reservoir: Mutex<LeadTimeReservoir>,
 
     /// Rolling log of per-slot decode outcomes emitted by the decoder.
     /// Capped at SLOT_LOG_CAP; oldest entries are evicted when full.
@@ -166,6 +168,7 @@ pub struct SourceMetricsSnapshot {
     pub coverage_shreds_expected: u64,
     pub fec_recovered_shreds: u64,
     pub txs_decoded: u64,
+    pub txs_dropped: u64,
     pub txs_emitted: u64,
     pub txs_first: u64,
     pub txs_duplicate: u64,
@@ -199,6 +202,7 @@ impl SourceMetrics {
             coverage_shreds_expected: AtomicU64::new(0),
             fec_recovered_shreds: AtomicU64::new(0),
             txs_decoded: AtomicU64::new(0),
+            txs_dropped: AtomicU64::new(0),
             txs_emitted: AtomicU64::new(0),
             txs_first: AtomicU64::new(0),
             txs_duplicate: AtomicU64::new(0),
@@ -314,6 +318,7 @@ impl SourceMetrics {
             coverage_shreds_expected: self.coverage_shreds_expected.load(Relaxed),
             fec_recovered_shreds: self.fec_recovered_shreds.load(Relaxed),
             txs_decoded: self.txs_decoded.load(Relaxed),
+            txs_dropped: self.txs_dropped.load(Relaxed),
             txs_emitted: self.txs_emitted.load(Relaxed),
             txs_first: self.txs_first.load(Relaxed),
             txs_duplicate: self.txs_duplicate.load(Relaxed),

--- a/crates/shred-ingest/src/thor_source.rs
+++ b/crates/shred-ingest/src/thor_source.rs
@@ -159,7 +159,7 @@ async fn run_thor(
 
     while let Some(msg) = stream.next().await {
         let msg = msg?;
-        let recv_ns = metrics::now_ns();
+        let recv_ns = metrics::now_realtime_ns();
 
         metrics.txs_decoded.fetch_add(1, Relaxed);
 


### PR DESCRIPTION
Some timing issues that our robot friend uncovered:

  Bug 1 — geyser_source.rs, jetstream_source.rs, thor_source.rs, jito_source.rs: changed now_ns() → now_realtime_ns() so cross-tier lead time uses the same clock domain as shred kernel timestamps.

  Bug 2 — decoder.rs: Added earliest_recv_ns field to SlotState, initialized to u64::MAX, updated to min(current, raw_shred.recv_timestamp_ns) on every shred arrival (both data and FEC paths). DecodedTx now carries earliest_recv_ns instead of the completing shred's timestamp.

  Bug 3 — fan_in.rs: Added CrossTierRecord struct and cross_tier field to FirstArrival. When a cross-tier lead time is recorded, the RPC timestamp and old lead are saved. When a faster shred source later updates the entry, the lead time sum and win count are corrected on both the old and new metrics, and a corrected sample is pushed to the reservoir and race tracker.

  Bug 4 — source_metrics.rs: Added txs_dropped: AtomicU64 to SourceMetrics and SourceMetricsSnapshot. decoder.rs: Both try_send call sites now increment txs_dropped on failure instead of silently discarding.